### PR TITLE
Use another environment variable than PORT to set the listening port.

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from prometheus_client.core import REGISTRY
 from sonar.sonar import SonarCollector
 
 
-PORT = int(os.environ.get('PORT', '9119'))
+PORT = int(os.environ.get('SONAR_EXPORTER_PORT', '9119'))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As DCOS exports a `PORT` environment variable per networking configuration to represent dynamically exposed container port, we should use another environment variable name to specify the exporter listening port. Otherwise, healthchecks from DCOS on "default" port 9119 would fail as the exporter would start listening on the dynamically allocated port rather than the expected one.